### PR TITLE
doc(api): fixed wrong response of /auth/login

### DIFF
--- a/doc/api-design.yml
+++ b/doc/api-design.yml
@@ -697,8 +697,8 @@ paths:
                 properties:
                   token:
                     type: string
-                  user:
-                    $ref: '#/components/schemas/User'
+                  message:
+                    type: string
         '401':
           description: Unauthorized
           content:


### PR DESCRIPTION
The wrong response solved: I removed User object and added "message: 'Login succesful'".