### PR TITLE
Getting 4 images from wikidata

### DIFF
--- a/backend/src/main/java/com/quizzard/quizzard/model/response/FavoriteQuestionResponse.java
+++ b/backend/src/main/java/com/quizzard/quizzard/model/response/FavoriteQuestionResponse.java
@@ -20,7 +20,7 @@ public class FavoriteQuestionResponse {
     public FavoriteQuestionResponse(FavoriteQuestion favoriteQuestion) {
         this.id = favoriteQuestion.getId();
         this.userId = favoriteQuestion.getUser().getId();
-        this.questionId = favoriteQuestion.getId();
+        this.questionId = favoriteQuestion.getQuestion().getId();
         this.createdAt = favoriteQuestion.getCreatedAt();
         this.updatedAt = favoriteQuestion.getUpdatedAt();
     }

--- a/backend/src/main/java/com/quizzard/quizzard/service/WikidataService.java
+++ b/backend/src/main/java/com/quizzard/quizzard/service/WikidataService.java
@@ -32,7 +32,7 @@ public class WikidataService {
 
         // Limit to first 3 URLs
         List<String> selectedUrls = sortedConceptUris.stream()
-                .limit(3)
+                .limit(2)
                 .collect(Collectors.toList());
 
         List<String> finalUrls = new ArrayList<>();
@@ -70,14 +70,22 @@ public class WikidataService {
             if (jsonResponse.has("claims") &&
                     jsonResponse.getJSONObject("claims").has("P18")) {
                 JSONArray claims = jsonResponse.getJSONObject("claims").getJSONArray("P18");
+                if (claims.length() > 1) {
+                    for (int i = 0; i < 2; i++) {
+                        String imageName = claims.getJSONObject(i).getJSONObject("mainsnak").getJSONObject("datavalue").getString("value");
 
-                for (int i = 0; i < 1; i++) {
-                    String imageName = claims.getJSONObject(i).getJSONObject("mainsnak").getJSONObject("datavalue").getString("value");
+                        // Create URL for getting image from Wikimedia Commons
+                        String imageUrl = WIKIDATA_COMMON_URL + imageName.replace(" ", "_");
+                        finalUrls.add(imageUrl);
+                    }
+                } else if (claims.length() == 1) {
+                    String imageName = claims.getJSONObject(0).getJSONObject("mainsnak").getJSONObject("datavalue").getString("value");
 
                     // Create URL for getting image from Wikimedia Commons
                     String imageUrl = WIKIDATA_COMMON_URL + imageName.replace(" ", "_");
                     finalUrls.add(imageUrl);
                 }
+
             }
         }
 


### PR DESCRIPTION
Previously, we were getting 3 images in total, one from each of the 3 wikidata entries. Now, we are getting 2 images from each of the 2 wikidata entries (if any). In this way, we aim to increase the number of relevant images while decreasing the number of irrelevant images.