### PR TITLE
fix(backend): fixed difficulty level of quizzes created from favorites

### DIFF
--- a/backend/src/main/java/com/quizzard/quizzard/service/QuizService.java
+++ b/backend/src/main/java/com/quizzard/quizzard/service/QuizService.java
@@ -192,6 +192,7 @@ public class QuizService {
             questionRepository.save(question);
         }
         quiz.setDifficulty(calculateQuizDifficulty(quiz));
+        quizRepository.save(quiz);
         return mapQuizToQuizResponse(quiz);
     }
 


### PR DESCRIPTION
Difficulty level of the quizzes created from favorite questions was 0. The bug is fixed with this PR.